### PR TITLE
Feat(#56) 대시보드 수정 컴포넌트 구현

### DIFF
--- a/src/components/modal/EditDashboardCard.tsx
+++ b/src/components/modal/EditDashboardCard.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from "react";
+import SelectColorCircle from "./SelectColorCircle";
+import { updateDashboard } from "@/libs/api/dashboards";
+
+interface EditDashboardCardProps {
+  dashboardId: number;
+  dashboardTitle: string;
+}
+
+export default function EditDashboardCard({
+  dashboardId,
+  dashboardTitle,
+}: EditDashboardCardProps) {
+  const [title, setTitle] = useState<string>("");
+  const [color, setColor] = useState<string>("");
+  const [selectedColor, setSelectedColor] = useState<string>("");
+
+  // 대시보드 변경요청 api
+  const editDashboard = async (): Promise<void> => {
+    try {
+      const data = await updateDashboard(dashboardId, {
+        title: title,
+        color: selectedColor,
+      });
+      console.log("대시보드가 성공적으로 업데이트되었습니다:", data);
+    } catch (error) {
+      console.error("대시보드 업데이트 실패:", error);
+    }
+  };
+
+  return (
+    <>
+      <div className="h-[344px] w-[620px] gap-3 rounded-2xl bg-white p-9 shadow-lg">
+        {/* 대시보드 title을 받아서 출력 */}
+        <div>
+          <h2 className="mb-7 text-2xl font-bold">
+            비브리지
+            {dashboardTitle}
+          </h2>
+          <label htmlFor="대시보드" className={"text-lg font-medium"}>
+            대시보드 이름
+          </label>
+          {/* 변경할 대시보드 title 입력 */}
+          <input
+            type="text"
+            placeholder="생성할 대시보드 이름을 입력해 주세요"
+            className="mb-5 mt-4 w-full rounded-lg border p-2"
+            onChange={(e) => {
+              setTitle(e.target.value);
+            }}
+          />
+          <div>
+            {/* 색상 선택 동그라미 */}
+            <ul className="flex gap-2">
+              {["#7AC555", "#760DDE", "#FFA500", "#76A5EA", "#E876EA"].map(
+                (color) => (
+                  <SelectColorCircle
+                    key={color}
+                    color={color}
+                    setColor={setColor}
+                    selectedColor={selectedColor}
+                    setSelectedColor={setSelectedColor}
+                  />
+                ),
+              )}
+            </ul>
+          </div>
+          {/* 변경 요청을 보내는 버튼 */}
+          <div className="mt-8 flex justify-end gap-2 rounded-lg border border-gray-200">
+            <button
+              className={
+                "h-14 w-full rounded px-4 py-2 hover:bg-violet hover:text-white"
+              }
+              onClick={editDashboard}
+            >
+              변경
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -93,7 +93,6 @@ audio,
 video {
   margin: 0;
   padding: 0;
-  border: 0;
   font-size: 100%;
   vertical-align: baseline;
 }


### PR DESCRIPTION
- 제목 : feat(issue 번호): 기능명
  ex) feat(17): pull request template 작성
  (확인 후 지워주세요)
  
## 🧩 이슈 번호 <!-- 이슈 번호 입력 -->
- [Taskify #56 ]

  <br/>

## 🔎 작업 내용

- 대시보드 수정 페이지에서 대시보드의 `이름`과 `색상`을 변경 할 수 있는 컴포넌트

  <br/>

## 이미지 첨부

![image](https://github.com/user-attachments/assets/d69cad3e-2d28-4471-9bf6-d9e5e223a0f4)
<br/>

## 🔧 앞으로의 과제

-  dashboardId,  dashboardTitle 을 넘겨주는 방법 고민해봐야 할 것 같습니다 (전역으로 할 지)

-  수정 요청이 잘 가는 지 잘 모르겠습니다. 400에러가 발생하는데 이게 대시보드 연결을 안해서 인지 헷갈립니다.
시간이 부족해서 우선 올립니다 

- `boder` 적용이 안되는 문제가 `gobal.css` 에서 문제가 있는 거 같아서 삭제했습니다. 
  <br/>

